### PR TITLE
Possible fix for #27

### DIFF
--- a/s3b_import.yaml
+++ b/s3b_import.yaml
@@ -473,9 +473,6 @@ voice_assistant:
   on_tts_end: 
     - display.page.show: replying_page
     - component.update: s3_box_lcd
-    - delay: 5s 
-    - display.page.show: idle_page
-    - component.update: s3_box_lcd
   on_end:
     - if:
         condition:
@@ -484,6 +481,8 @@ voice_assistant:
           - wait_until:
               not:
                 voice_assistant.is_running:
+          - display.page.show: idle_page
+          - component.update: s3_box_lcd
           - micro_wake_word.start
         else:
           - wait_until:


### PR DESCRIPTION
In your YAML, you hardcode a delay of 5 seconds before the listening image disappears in favour of the homepage. Doing so obviously cuts off longer responses, specifically of those from an LLM. This PR should fix that by moving the switch to the homepage to when Assist _actually_ finishes talking, or at least a second after.
Also this is dipper998 from Discord by the way and I hope this isn't my first PR here, should have another one at some point with those substitutions I was talking about.

@Unreality81 (if this mentions you) - could you see if this small change fixes your issue (#27)?