### PR TITLE
start saver_enabled after VA is done

### DIFF
--- a/s3b_import.yaml
+++ b/s3b_import.yaml
@@ -464,7 +464,6 @@ voice_assistant:
   auto_gain: 31dBFS
   volume_multiplier: 4.0
   on_listening:
-    - script.execute: saver_enabled
     - display.page.show: listening_page
     - component.update: s3_box_lcd
   on_stt_vad_end: 
@@ -481,6 +480,7 @@ voice_assistant:
           - wait_until:
               not:
                 voice_assistant.is_running:
+          - script.execute: saver_enabled
           - display.page.show: idle_page
           - component.update: s3_box_lcd
           - micro_wake_word.start


### PR DESCRIPTION
Currently, saver_enabled starts while the Voice Assistant is listening. Therefore, if you change the timeout to less than the default 30s, you might find the screensaver start while the VA is still answering. This should fix that by starting the script _after_ it's done talking. Obviously, there's other things we're working on too but thought this would be a nice little bug fix for people using the current version.