### PR TITLE
Update s3b.yaml - added "invert_colors: true" to display config

### DIFF
--- a/s3b.yaml
+++ b/s3b.yaml
@@ -706,6 +706,7 @@ display:
       number: 48
       inverted: true
     update_interval: never
+    invert_colors: false
     ##################################################################################################
     ################ The below section defines, what is displayed on the screen,        ##############
     ################ the colours and mdi icons are defined above under font: and Color: ##############


### PR DESCRIPTION
The code wouldn't compile with this config missing. I've added the default value of true and it now compiles with the display showing the correct colours.